### PR TITLE
Handle cancelled media selections

### DIFF
--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -5,6 +5,7 @@ import 'dart:io' show Directory, File, FileSystemEntity, Platform;
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:file_picker_cross/file_picker_cross.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:image_picker/image_picker.dart';
@@ -632,12 +633,19 @@ class HomePageController extends MyState<HomePage> {
     }
   }
 
-  _pickMediaFile(
-      BuildContext context, Function pickMethod, ImageSource source) async {
+  _pickMediaFile(BuildContext context,
+      Future<XFile> Function({ImageSource source}) pickMethod,
+      ImageSource source) async {
     isLoading = true;
     final XFile selectedFile = await pickMethod(
       source: source,
     );
+
+    if (selectedFile == null) {
+      isLoading = false;
+      return;
+    }
+
     var size = await File(selectedFile.path).length();
     if (size >= 20000000) {
       isLoading = false;
@@ -664,6 +672,15 @@ class HomePageController extends MyState<HomePage> {
         isLoading = false;
       }
     }
+  }
+
+  @visibleForTesting
+  Future<void> pickMediaFileForTest(
+    BuildContext context,
+    Future<XFile> Function({ImageSource source}) pickMethod,
+    ImageSource source,
+  ) async {
+    await _pickMediaFile(context, pickMethod, source);
   }
 
   Future<PackageInfo> _getPackageInfo() async {

--- a/test/pages/home/home_page_controller_test.dart
+++ b/test/pages/home/home_page_controller_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:navy_encrypt/pages/home/home_page.dart';
+
+class _TestNavigatorObserver extends NavigatorObserver {
+  int pushCount = 0;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic> previousRoute) {
+    if (route.settings?.name != Navigator.defaultRouteName) {
+      pushCount++;
+    }
+    super.didPush(route, previousRoute);
+  }
+}
+
+void main() {
+  testWidgets('image picker returning null stops loading and avoids navigation',
+      (tester) async {
+    final observer = _TestNavigatorObserver();
+    await tester.pumpWidget(MaterialApp(
+      home: HomePage(key: UniqueKey()),
+      navigatorObservers: [observer],
+    ));
+    await tester.pumpAndSettle();
+
+    final state = tester.state<HomePageController>(find.byType(HomePage));
+
+    await state.pickMediaFileForTest(
+      state.context,
+      ({ImageSource source}) async => null,
+      ImageSource.camera,
+    );
+    await tester.pump();
+
+    expect(state.isLoading, isFalse);
+    expect(observer.pushCount, 0);
+  });
+
+  testWidgets('video picker returning null stops loading and avoids navigation',
+      (tester) async {
+    final observer = _TestNavigatorObserver();
+    await tester.pumpWidget(MaterialApp(
+      home: HomePage(key: UniqueKey()),
+      navigatorObservers: [observer],
+    ));
+    await tester.pumpAndSettle();
+
+    final state = tester.state<HomePageController>(find.byType(HomePage));
+
+    await state.pickMediaFileForTest(
+      state.context,
+      ({ImageSource source}) async => null,
+      ImageSource.gallery,
+    );
+    await tester.pump();
+
+    expect(state.isLoading, isFalse);
+    expect(observer.pushCount, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- guard the media picker flow against null selections and expose a testing helper
- add widget coverage that verifies camera and gallery cancellations stop loading without navigation

## Testing
- flutter test test/pages/home/home_page_controller_test.dart *(fails: flutter command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0576f5688322a3156ade8de53f05