### PR TITLE
Stabilize Firebase initialization across platforms

### DIFF
--- a/lib/common/firebase_bootstrap.dart
+++ b/lib/common/firebase_bootstrap.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Hosts the logic that ensures Firebase is configured for the current platform
+/// before the main application starts running.  The original bootstrap logic
+/// lived directly inside `main.dart` and executed unconditionally which caused
+/// crashes on platforms that do not yet ship with Firebase configuration files
+/// (for example the Windows build).  The helper methods below centralise the
+/// behaviour and make the decisions more explicit which allows the desktop
+/// workflow to function again.
+Future<void> configureFirebase() async {
+  if (kIsWeb) {
+    await _initializeFirebaseApp();
+    await _configureAuthEmulatorIfNeeded();
+    return;
+  }
+
+  if (_supportsFirebaseOnIo()) {
+    await _initializeFirebaseApp();
+    await _configureAuthEmulatorIfNeeded();
+  }
+}
+
+bool _supportsFirebaseOnIo() {
+  return Platform.isAndroid || Platform.isIOS || Platform.isMacOS;
+}
+
+Future<void> _initializeFirebaseApp() async {
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp();
+  }
+}
+
+Future<void> _configureAuthEmulatorIfNeeded() async {
+  if (!_shouldUseAuthEmulator() || Firebase.apps.isEmpty) {
+    return;
+  }
+
+  try {
+    await FirebaseAuth.instance.useAuthEmulator(_emulatorHost, _emulatorPort);
+  } on FirebaseAuthException catch (error) {
+    debugPrint('Failed to connect to Firebase Auth emulator: ${error.message}');
+  } on PlatformException catch (error) {
+    debugPrint('Failed to connect to Firebase Auth emulator: ${error.message}');
+  }
+}
+
+bool _shouldUseAuthEmulator() {
+  if (kReleaseMode) {
+    return false;
+  }
+
+  return const bool.fromEnvironment('USE_FIREBASE_AUTH_EMULATOR', defaultValue: true);
+}
+
+const String _emulatorHost = 'localhost';
+const int _emulatorPort = 9099;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:navy_encrypt/etc/constants.dart';
 import 'package:navy_encrypt/etc/share_intent_handler.dart';
+import 'package:navy_encrypt/common/firebase_bootstrap.dart';
 import 'package:navy_encrypt/models/loading_message.dart';
 import 'package:navy_encrypt/pages/cloud_picker/cloud_picker_page.dart';
 import 'package:navy_encrypt/pages/decryption/decryption_page.dart';
@@ -25,7 +24,7 @@ import 'package:window_size/window_size.dart';
 //https://flutter.dev/docs/get-started/flutter-for/android-devs#how-do-i-handle-incoming-intents-from-external-applications-in-flutter
 //https://github.com/flutter/flutter/issues/32986
 
-String filePathFromCli;
+String filePathFromCli = '';
 
 class MyHttpOverrides extends HttpOverrides {
   @override
@@ -40,18 +39,7 @@ Future<void> main(List<String> arguments) async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // get command-line arg in desktop app
-  // if (Platform.isAndroid == true || Platform.isIOS == true) {
-  if (Platform.isWindows) {
-  } else {
-    // WidgetsFlutterBinding.ensureInitialized();
-    WidgetsFlutterBinding.ensureInitialized();
-    await Firebase.initializeApp();
-  }
-
-  // }
-
-// Ideal time to initialize
-  await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+  await configureFirebase();
 
   SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # Read more about Android versioning at https://developer.android.com/studio/publish/versioning
 # In iOS, build-name is used as CFBundleShortVersionString wAdvertisinghile build-number used as CFBundleVersion.
 # Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
+# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys
 version: 3.0.1+4
 
 # Flutter Version 3.3.8


### PR DESCRIPTION
## Summary
- extract Firebase bootstrap into a dedicated helper so unsupported platforms skip Firebase setup gracefully
- guard Firebase Auth emulator configuration behind platform checks and a build-time flag
- tidy the pubspec metadata comment to remove the stray `.html` suffix and restore the file newline

## Testing
- Not run (Flutter SDK is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e4ed0a423c832283e261bc2a859d2c