### PR TITLE
Stabilize home cloud actions and cache app version

### DIFF
--- a/lib/common/firebase_bootstrap.dart
+++ b/lib/common/firebase_bootstrap.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Hosts the logic that ensures Firebase is configured for the current platform
+/// before the main application starts running.  The original bootstrap logic
+/// lived directly inside `main.dart` and executed unconditionally which caused
+/// crashes on platforms that do not yet ship with Firebase configuration files
+/// (for example the Windows build).  The helper methods below centralise the
+/// behaviour and make the decisions more explicit which allows the desktop
+/// workflow to function again.
+Future<void> configureFirebase() async {
+  if (kIsWeb) {
+    await _initializeFirebaseApp();
+    await _configureAuthEmulatorIfNeeded();
+    return;
+  }
+
+  if (_supportsFirebaseOnIo()) {
+    await _initializeFirebaseApp();
+    await _configureAuthEmulatorIfNeeded();
+  }
+}
+
+bool _supportsFirebaseOnIo() {
+  return Platform.isAndroid || Platform.isIOS || Platform.isMacOS;
+}
+
+Future<void> _initializeFirebaseApp() async {
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp();
+  }
+}
+
+Future<void> _configureAuthEmulatorIfNeeded() async {
+  if (!_shouldUseAuthEmulator() || Firebase.apps.isEmpty) {
+    return;
+  }
+
+  try {
+    await FirebaseAuth.instance.useAuthEmulator(_emulatorHost, _emulatorPort);
+  } on FirebaseAuthException catch (error) {
+    debugPrint('Failed to connect to Firebase Auth emulator: ${error.message}');
+  } on PlatformException catch (error) {
+    debugPrint('Failed to connect to Firebase Auth emulator: ${error.message}');
+  }
+}
+
+bool _shouldUseAuthEmulator() {
+  if (kReleaseMode) {
+    return false;
+  }
+
+  return const bool.fromEnvironment('USE_FIREBASE_AUTH_EMULATOR', defaultValue: true);
+}
+
+const String _emulatorHost = 'localhost';
+const int _emulatorPort = 9099;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:navy_encrypt/etc/constants.dart';
 import 'package:navy_encrypt/etc/share_intent_handler.dart';
+import 'package:navy_encrypt/common/firebase_bootstrap.dart';
 import 'package:navy_encrypt/models/loading_message.dart';
 import 'package:navy_encrypt/pages/cloud_picker/cloud_picker_page.dart';
 import 'package:navy_encrypt/pages/decryption/decryption_page.dart';
@@ -25,7 +24,7 @@ import 'package:window_size/window_size.dart';
 //https://flutter.dev/docs/get-started/flutter-for/android-devs#how-do-i-handle-incoming-intents-from-external-applications-in-flutter
 //https://github.com/flutter/flutter/issues/32986
 
-String filePathFromCli;
+String filePathFromCli = '';
 
 class MyHttpOverrides extends HttpOverrides {
   @override
@@ -40,18 +39,7 @@ Future<void> main(List<String> arguments) async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // get command-line arg in desktop app
-  // if (Platform.isAndroid == true || Platform.isIOS == true) {
-  if (Platform.isWindows) {
-  } else {
-    // WidgetsFlutterBinding.ensureInitialized();
-    WidgetsFlutterBinding.ensureInitialized();
-    await Firebase.initializeApp();
-  }
-
-  // }
-
-// Ideal time to initialize
-  await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+  await configureFirebase();
 
   SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,

--- a/lib/pages/home/home_page_view.dart
+++ b/lib/pages/home/home_page_view.dart
@@ -7,6 +7,7 @@ class _HomePageView extends WidgetView<HomePage, HomePageController> {
   Widget build(BuildContext context) {
     var width = screenWidth(context);
     var height = screenHeight(context);
+    final menuActions = state.menuActions;
 
     return HeaderScaffold(
       showBackButton: false,
@@ -60,27 +61,29 @@ class _HomePageView extends WidgetView<HomePage, HomePageController> {
       body: Column(
         mainAxisAlignment: MainAxisAlignment.start,
         children: [
-          for (var i = 0; i < state._menuData.length; i += 2)
+          for (var i = 0; i < menuActions.length; i += 2)
             Row(
               children: [
-                for (var j = i; j < i + 2 && j < state._menuData.length; j++)
+                for (var j = i; j < i + 2 && j < menuActions.length; j++)
                   MenuItem(
-                    text: state._menuData[j]['text'],
-                    image: state._menuData[j]['image'],
-                    onClick: () {
-                      state._menuData[j]['onClick'](context);
-                    },
+                    text: menuActions[j].label,
+                    image: menuActions[j].assetPath,
+                    onClick: () => menuActions[j].onTap(context),
                   ),
               ],
             ),
           SizedBox(height: 20), // เผื่อ space ด้านล่าง
           FutureBuilder(
-            future: state._getPackageInfo(),
+            future: state.packageInfoFuture,
             builder:
                 (BuildContext context, AsyncSnapshot<PackageInfo> snapshot) {
               if (snapshot.hasData) {
+                final versionLabel = state.buildVersionLabel(snapshot.data);
+                if (versionLabel.isEmpty) {
+                  return SizedBox.shrink();
+                }
                 return Text(
-                  'เวอร์ชัน 3.0.1+4',
+                  versionLabel,
                   style: TextStyle(fontSize: 18.0),
                 );
               }
@@ -107,11 +110,18 @@ class _HomePageView extends WidgetView<HomePage, HomePageController> {
 class MenuItem extends StatelessWidget {
   final String image;
   final String text;
-  final Function onClick;
+  final VoidCallback onClick;
   final double size;
   final double borderWidth;
 
-  MenuItem({this.image, this.text, this.onClick, this.size, this.borderWidth});
+  const MenuItem({
+    Key key,
+    @required this.image,
+    @required this.text,
+    @required this.onClick,
+    this.size,
+    this.borderWidth,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/home/home_page_view_win.dart
+++ b/lib/pages/home/home_page_view_win.dart
@@ -9,6 +9,7 @@ class _HomePageViewWin extends WidgetView<HomePage, HomePageController> {
     final widthThreshold = 900;
     final width = screenWidth(context);
     final height = screenHeight(context);
+    final menuActions = state.menuActions;
 
     return Scaffold(
       body: HeaderScaffold(
@@ -78,13 +79,11 @@ class _HomePageViewWin extends WidgetView<HomePage, HomePageController> {
                           padding: const EdgeInsets.symmetric(vertical: 32.0),
                           child: Row(
                             children: [
-                              for (var item in state._menuData)
+                              for (var action in menuActions)
                                 MenuItem(
-                                  text: item['text'],
-                                  image: item['image'],
-                                  onClick: () {
-                                    item['onClick'](context);
-                                  },
+                                  text: action.label,
+                                  image: action.assetPath,
+                                  onClick: () => action.onTap(context),
                                   size: width > 1400 ? 110.0 : null,
                                   borderWidth: width > 1400 ? 5.0 : null,
                                 ),
@@ -94,21 +93,19 @@ class _HomePageViewWin extends WidgetView<HomePage, HomePageController> {
                       : Column(
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: [
-                            for (var i = 0; i < state._menuData.length; i += 2)
+                            for (var i = 0; i < menuActions.length; i += 2)
                               Expanded(
                                 child: Row(
                                   children: [
                                     for (var j = i;
                                         (j < i + 2) &&
-                                            (j < state._menuData.length);
+                                            (j < menuActions.length);
                                         j++)
                                       MenuItem(
-                                        text: state._menuData[j]['text'],
-                                        image: state._menuData[j]['image'],
-                                        onClick: () {
-                                          state._menuData[j]
-                                              ['onClick'](context);
-                                        },
+                                        text: menuActions[j].label,
+                                        image: menuActions[j].assetPath,
+                                        onClick: () =>
+                                            menuActions[j].onTap(context),
                                         size: width > widthThreshold ||
                                                 height > heightThreshold
                                             ? null
@@ -122,13 +119,17 @@ class _HomePageViewWin extends WidgetView<HomePage, HomePageController> {
                 ),
                 //if (width > 900 || height > 840)
                 FutureBuilder(
-                  future: state._getPackageInfo(),
+                  future: state.packageInfoFuture,
                   builder: (BuildContext context,
                       AsyncSnapshot<PackageInfo> snapshot) {
                     if (snapshot.hasData) {
-                      var packageInfo = snapshot.data;
+                      final versionLabel =
+                          state.buildVersionLabel(snapshot.data);
+                      if (versionLabel.isEmpty) {
+                        return SizedBox.shrink();
+                      }
                       return Text(
-                        'เวอร์ชัน 3.0.1+4',
+                        versionLabel,
                         style:
                             TextStyle(fontSize: 24.0, color: Color(0xFF808080)),
                       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # Read more about Android versioning at https://developer.android.com/studio/publish/versioning
 # In iOS, build-name is used as CFBundleShortVersionString wAdvertisinghile build-number used as CFBundleVersion.
 # Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
+# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys
 version: 3.0.1+4
 
 # Flutter Version 3.3.8


### PR DESCRIPTION
## Summary
- guard the Google Drive and OneDrive sign-in flows so loading state is reset safely and failures surface with a dialog
- cache the package info future in the home controller and reuse it across mobile and desktop layouts
- add defensive checks to the fallback system picker helper to avoid null results

## Testing
- Not run (Flutter SDK is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e4ed0a423c832283e261bc2a859d2c