### PR TITLE
Handle decryption errors more defensively

### DIFF
--- a/lib/navy_encryption/navec.dart
+++ b/lib/navy_encryption/navec.dart
@@ -322,18 +322,31 @@ class Navec {
       orElse: () => null,
     );
 
-    File outFile;
-    fileBytes = await File(filePath).readAsBytes();
+    if (algo == null) {
+      showOkDialog(
+        context,
+        'ผิดพลาด',
+        textContent: 'ไฟล์ถูกเข้ารหัสด้วย Algorithm ที่แอปนี้ไม่รองรับ',
+      );
+      return null;
+    }
 
-    var decryptedBytes = algo.decrypt(
-        password, fileBytes.sublist(contentBeginIndex, contentEndIndex));
-    //
-    //
-    //
+    final encryptedContent = fileBytes.sublist(contentBeginIndex, contentEndIndex);
+    final decryptedBytes = algo.decrypt(password, encryptedContent);
+
+    if (decryptedBytes == null) {
+      showOkDialog(
+        context,
+        'ผิดพลาด',
+        textContent: 'รหัสผ่านไม่ถูกต้อง หรือเกิดข้อผิดพลาดในการถอดรหัส',
+      );
+      return null;
+    }
+
     var outFilename = '${p.basenameWithoutExtension(filePath)}.$fileExtension';
     logMap['Decrypted file name'] = outFilename;
 
-    outFile = await FileUtil.createFileFromBytes(
+    var outFile = await FileUtil.createFileFromBytes(
       outFilename,
       Uint8List.fromList(decryptedBytes),
     );

--- a/lib/pages/decryption/decryption_page.dart
+++ b/lib/pages/decryption/decryption_page.dart
@@ -105,16 +105,23 @@ class _DecryptionPageController extends MyState<DecryptionPage> {
         filePath: _toBeDecryptedFilePath,
         password: password,
       );
-      print("decrypt = ${decryptData[0]}");
-      print("decrypt = ${decryptData[1]}");
-      // var uuid = Uuid();
+
+      if (decryptData == null) {
+        isLoading = false;
+        return;
+      }
 
       outFile = decryptData[0];
       uuid = decryptData[1];
-      // var uid = Uuid();
-      // uuid = uid.v4();
+
+      if (outFile == null) {
+        isLoading = false;
+        return;
+      }
     } on Exception catch (e) {
+      isLoading = false;
       showOkDialog(context, 'เกิดข้อผิดพลาดในการถอดรหัส: $e');
+      return;
     }
     String getLog;
 

--- a/test/pages/decryption/decryption_page_test.dart
+++ b/test/pages/decryption/decryption_page_test.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:navy_encrypt/common/header_scaffold.dart';
+import 'package:navy_encrypt/navy_encryption/navec.dart';
+import 'package:navy_encrypt/pages/decryption/decryption_page.dart';
+import 'package:navy_encrypt/storage/prefs.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('DecryptionPage', () {
+    Directory tempDir;
+    File encryptedFile;
+    const correctPassword = 'correct-password';
+    const uuid = '12345678-1234-1234-1234-123456789012';
+
+    setUp(() async {
+      await SharedPreferences.setMockInitialValues({
+        MyPrefs.KEY_EMAIL: 'tester@example.com',
+        MyPrefs.KEY_SECRET: 'secret',
+      });
+
+      tempDir ??= await Directory.systemTemp.createTemp('navec_test');
+
+      if (encryptedFile == null) {
+        final plainBytes = Uint8List.fromList(utf8.encode('Sample content'));
+        final aes128 = Navec.algorithms
+            .firstWhere((algo) => algo.code == 'AES128');
+        final encryptedBytes = aes128.encrypt(correctPassword, plainBytes);
+
+        final header = <int>[
+          ...utf8.encode(Navec.headerFileSignature),
+          ...utf8.encode(
+            'txt'.padRight(Navec.headerFileExtensionFieldLength),
+          ),
+          ...utf8.encode(
+            aes128.code.padRight(Navec.headerAlgorithmFieldLength),
+          ),
+          ...encryptedBytes,
+          ...utf8.encode(uuid),
+        ];
+
+        encryptedFile = await File(p.join(tempDir.path, 'sample.enc'))
+            .writeAsBytes(header, flush: true);
+      }
+    });
+
+    tearDownAll(() async {
+      if (encryptedFile != null && await encryptedFile.exists()) {
+        await encryptedFile.delete();
+      }
+      if (tempDir != null && await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    testWidgets('shows error dialog when password is incorrect',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        initialRoute: DecryptionPage.routeName,
+        onGenerateRoute: (settings) {
+          if (settings.name == DecryptionPage.routeName) {
+            return MaterialPageRoute(
+              settings: RouteSettings(
+                name: settings.name,
+                arguments: encryptedFile.path,
+              ),
+              builder: (_) => DecryptionPage(),
+            );
+          }
+          return null;
+        },
+      ));
+
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField), 'wrong-password');
+      await tester.tap(find.text('ดำเนินการ'));
+
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('รหัสผ่านไม่ถูกต้อง หรือเกิดข้อผิดพลาดในการถอดรหัส'),
+        findsOneWidget,
+      );
+
+      final headerScaffold = tester.widget<HeaderScaffold>(
+        find.byType(HeaderScaffold),
+      );
+      expect(headerScaffold.showProgress, isFalse);
+
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- prevent `decryptFile` from calling unsupported algorithms and show an error dialog instead
- abort decryption when the algorithm returns null bytes and propagate the failure to the UI so loading stops
- add a widget test that covers the wrong-password path to ensure the error dialog is shown without crashing

## Testing
- flutter test test/pages/decryption/decryption_page_test.dart *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e1cd27fc8322887dde0b2eb237f5