### PR TITLE
Harden NAVEC decryption validation and add flow test

### DIFF
--- a/lib/navy_encryption/navec.dart
+++ b/lib/navy_encryption/navec.dart
@@ -299,6 +299,15 @@ class Navec {
     var fileBytes = await File(filePath).readAsBytes();
 
     final signatureLength = Navec.headerFileSignature.length;
+    if (fileBytes.length < signatureLength) {
+      showOkDialog(
+        context,
+        'ผิดพลาด',
+        textContent: 'ไฟล์นี้ไม่ถูกต้อง หรืออาจไม่ได้ถูกเข้ารหัสด้วย NAVEC',
+      );
+      return null;
+    }
+
     bool hasVersion = false;
     if (fileBytes.length >=
         signatureLength + Navec.headerVersion.length) {
@@ -313,8 +322,19 @@ class Navec {
     var extensionFieldBeginIndex = signatureLength + versionLength;
     var algorithmFieldBeginIndex =
         extensionFieldBeginIndex + Navec.headerFileExtensionFieldLength;
-    var contentBeginIndex =
+    var minimumHeaderLength =
         algorithmFieldBeginIndex + Navec.headerAlgorithmFieldLength;
+
+    if (fileBytes.length < minimumHeaderLength) {
+      showOkDialog(
+        context,
+        'ผิดพลาด',
+        textContent: 'ไฟล์นี้ไม่ถูกต้อง หรืออาจได้รับความเสียหาย',
+      );
+      return null;
+    }
+
+    var contentBeginIndex = minimumHeaderLength;
 
     var logMap = <String, dynamic>{
       'Operation': 'Decryption',
@@ -325,6 +345,15 @@ class Navec {
     var fileSignature =
         utf8.decode(fileBytes.sublist(0, Navec.headerFileSignature.length));
     logMap['File signature'] = fileSignature;
+
+    if (fileSignature != Navec.headerFileSignature) {
+      showOkDialog(
+        context,
+        'ผิดพลาด',
+        textContent: 'ไฟล์นี้ไม่ถูกต้อง หรืออาจไม่ได้ถูกเข้ารหัสด้วย NAVEC',
+      );
+      return null;
+    }
 
     var fileExtension = utf8
         .decode(fileBytes.sublist(
@@ -373,18 +402,51 @@ class Navec {
       return null;
     }
 
+    if (contentEndIndex <= contentBeginIndex) {
+      showOkDialog(
+        context,
+        'ผิดพลาด',
+        textContent: 'ไฟล์ถูกเข้ารหัสไม่สมบูรณ์ หรือไฟล์อาจเสียหาย',
+      );
+      return null;
+    }
+
+    final payloadLength = contentEndIndex - contentBeginIndex;
+    if (hasVersion && algo is Aes && payloadLength <= Aes.ivLength) {
+      showOkDialog(
+        context,
+        'ผิดพลาด',
+        textContent: 'ไฟล์ถูกเข้ารหัสไม่สมบูรณ์ หรือไฟล์อาจเสียหาย',
+      );
+      return null;
+    }
+
     Uint8List ivBytes;
     if (hasVersion && algo is Aes) {
       final ivEndIndex = contentBeginIndex + Aes.ivLength;
-      if (ivEndIndex <= contentEndIndex) {
-        ivBytes = Uint8List.fromList(
-            fileBytes.sublist(contentBeginIndex, ivEndIndex));
-        contentBeginIndex = ivEndIndex;
+      if (ivEndIndex > contentEndIndex) {
+        showOkDialog(
+          context,
+          'ผิดพลาด',
+          textContent: 'ไฟล์ถูกเข้ารหัสไม่สมบูรณ์ หรือไฟล์อาจเสียหาย',
+        );
+        return null;
       }
+      ivBytes = Uint8List.fromList(
+          fileBytes.sublist(contentBeginIndex, ivEndIndex));
+      contentBeginIndex = ivEndIndex;
     }
 
     final encryptedSlice =
         fileBytes.sublist(contentBeginIndex, contentEndIndex);
+    if (encryptedSlice.isEmpty) {
+      showOkDialog(
+        context,
+        'ผิดพลาด',
+        textContent: 'ไฟล์ถูกเข้ารหัสไม่สมบูรณ์ หรือไฟล์อาจเสียหาย',
+      );
+      return null;
+    }
     Uint8List decryptedBytes = algo.decrypt(
       password,
       Uint8List.fromList(encryptedSlice),

--- a/lib/pages/encryption/encryption_page.dart
+++ b/lib/pages/encryption/encryption_page.dart
@@ -158,7 +158,15 @@ class _EncryptionPageController extends MyState<EncryptionPage> {
         showOkDialog(context, e.toString());
       }
 
-      signatureCode = _watermarkEditingController.text;
+      if (signatureCode == null || signatureCode.isEmpty) {
+        showOkDialog(
+          context,
+          'ผิดพลาด',
+          textContent: 'ไม่สามารถสร้างรหัสลายน้ำได้',
+        );
+        isLoading = false;
+        return;
+      }
       print("signatureCode1 = ${signatureCode}");
       print("signatureCode2 = ${signatureCode}");
       // ใส่ลายน้ำ

--- a/test/navy_encryption/navec_flow_test.dart
+++ b/test/navy_encryption/navec_flow_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:encrypt/encrypt.dart' as enc;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:navy_encrypt/navy_encryption/algorithms/aes.dart';
@@ -43,6 +44,18 @@ class _FakePathProviderPlatform extends PathProviderPlatform {
   Future<String> getDownloadsPath() async => _tempDir.path;
 }
 
+Future<BuildContext> _pumpTestContext(WidgetTester tester) async {
+  await tester.pumpWidget(MaterialApp(
+    home: Builder(
+      builder: (context) {
+        return const SizedBox.shrink();
+      },
+    ),
+  ));
+
+  return tester.element(find.byType(SizedBox));
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -67,15 +80,7 @@ void main() {
     const password = 'correct horse battery staple';
     const uuid = '00000000-0000-0000-0000-000000000001';
 
-    await tester.pumpWidget(MaterialApp(
-      home: Builder(
-        builder: (context) {
-          return const SizedBox.shrink();
-        },
-      ),
-    ));
-
-    final BuildContext context = tester.element(find.byType(SizedBox));
+    final BuildContext context = await _pumpTestContext(tester);
 
     final plainBytes = Uint8List.fromList(utf8.encode('Sensitive payload'));
     final sourceFile = await File(p.join(tempRoot.path, 'sample.txt'))
@@ -150,5 +155,133 @@ void main() {
     expect(recoveredUuid, uuid);
     final outputBytes = await outputFile.readAsBytes();
     expect(outputBytes, plainBytes);
+  });
+
+  testWidgets('encryptFile randomizes IV for subsequent AES operations',
+      (tester) async {
+    const password = 'correct horse battery staple';
+    const uuid = '00000000-0000-0000-0000-000000000002';
+
+    final BuildContext context = await _pumpTestContext(tester);
+
+    final plainBytes = Uint8List.fromList(utf8.encode('Sensitive payload'));
+    final sourceFile = await File(p.join(tempRoot.path, 'sample_iv.txt'))
+        .writeAsBytes(plainBytes, flush: true);
+    addTearDown(() async {
+      if (await sourceFile.exists()) {
+        await sourceFile.delete();
+      }
+    });
+
+    final algo = Navec.algorithms.firstWhere((item) => item.code == 'AES256');
+
+    final encryptedFileFirst = await Navec.encryptFile(
+      filePath: sourceFile.path,
+      password: password,
+      algo: algo,
+      uuid: uuid,
+    );
+    final firstBytes = await encryptedFileFirst.readAsBytes();
+
+    final encryptedFileSecond = await Navec.encryptFile(
+      filePath: sourceFile.path,
+      password: password,
+      algo: algo,
+      uuid: uuid,
+    );
+    addTearDown(() async {
+      if (await encryptedFileSecond.exists()) {
+        await encryptedFileSecond.delete();
+      }
+    });
+    final secondBytes = await encryptedFileSecond.readAsBytes();
+
+    expect(firstBytes, isNot(secondBytes));
+
+    final ivOffset = Navec.headerFileSignature.length +
+        Navec.headerVersion.length +
+        Navec.headerFileExtensionFieldLength +
+        Navec.headerAlgorithmFieldLength;
+
+    final firstIv = firstBytes.sublist(ivOffset, ivOffset + Aes.ivLength);
+    final secondIv = secondBytes.sublist(ivOffset, ivOffset + Aes.ivLength);
+    expect(firstIv, isNot(secondIv));
+
+    // Ensure the latest encrypted artifact still decrypts successfully.
+    final result = await Navec.decryptFile(
+      context: context,
+      filePath: encryptedFileSecond.path,
+      password: password,
+    );
+    final File outputFile = result[0] as File;
+    addTearDown(() async {
+      if (await outputFile.exists()) {
+        await outputFile.delete();
+      }
+    });
+    final outputBytes = await outputFile.readAsBytes();
+    expect(outputBytes, plainBytes);
+  });
+
+  testWidgets('decryptFile supports legacy AES payloads without version info',
+      (tester) async {
+    const password = 'correct horse battery staple';
+    const uuid = '00000000-0000-0000-0000-000000000003';
+
+    final BuildContext context = await _pumpTestContext(tester);
+
+    final plainBytes = Uint8List.fromList(utf8.encode('Legacy payload'));
+    final sourceFile = await File(p.join(tempRoot.path, 'legacy.txt'))
+        .writeAsBytes(plainBytes, flush: true);
+
+    final aesAlgo =
+        Navec.algorithms.firstWhere((item) => item.code == 'AES256') as Aes;
+
+    String textKey = password.trim();
+    while (textKey.length < aesAlgo.keyLengthInBytes) {
+      textKey = '$textKey${Navec.passwordPadChar}';
+    }
+    final key = enc.Key.fromUtf8(textKey);
+    final encrypter = enc.Encrypter(enc.AES(key));
+    final zeroIv = enc.IV.fromLength(Aes.ivLength);
+    final legacyCipher =
+        encrypter.encryptBytes(plainBytes, iv: zeroIv).bytes; // CBC default
+
+    final headerBytes = <int>[
+      ...utf8.encode(Navec.headerFileSignature),
+      ...utf8
+          .encode(p.extension(sourceFile.path).substring(1).padRight(Navec.headerFileExtensionFieldLength)),
+      ...utf8.encode(aesAlgo.code.padRight(Navec.headerAlgorithmFieldLength)),
+      ...legacyCipher,
+      ...utf8.encode(uuid),
+    ];
+
+    final legacyFile = await File(p.join(tempRoot.path, 'legacy.enc'))
+        .writeAsBytes(headerBytes, flush: true);
+    addTearDown(() async {
+      if (await legacyFile.exists()) {
+        await legacyFile.delete();
+      }
+      if (await sourceFile.exists()) {
+        await sourceFile.delete();
+      }
+    });
+
+    final result = await Navec.decryptFile(
+      context: context,
+      filePath: legacyFile.path,
+      password: password,
+    );
+
+    expect(result, isNotNull);
+    final File outputFile = result[0] as File;
+    addTearDown(() async {
+      if (await outputFile.exists()) {
+        await outputFile.delete();
+      }
+    });
+    final outputBytes = await outputFile.readAsBytes();
+    expect(outputBytes, plainBytes);
+    expect(result[1], uuid);
   });
 }

--- a/test/navy_encryption/navec_flow_test.dart
+++ b/test/navy_encryption/navec_flow_test.dart
@@ -1,0 +1,154 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:navy_encrypt/navy_encryption/algorithms/aes.dart';
+import 'package:navy_encrypt/navy_encryption/navec.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this._tempDir);
+
+  final Directory _tempDir;
+
+  @override
+  Future<String> getTemporaryPath() async => _tempDir.path;
+
+  @override
+  Future<String> getApplicationDocumentsPath() async => _tempDir.path;
+
+  @override
+  Future<String> getApplicationSupportPath() async => _tempDir.path;
+
+  @override
+  Future<String> getLibraryPath() async => _tempDir.path;
+
+  @override
+  Future<String> getApplicationCachePath() async => _tempDir.path;
+
+  @override
+  Future<String> getExternalStoragePath() async => _tempDir.path;
+
+  @override
+  Future<List<String>> getExternalCachePaths() async => <String>[_tempDir.path];
+
+  @override
+  Future<List<String>> getExternalStoragePaths({StorageDirectory type}) async =>
+      <String>[_tempDir.path];
+
+  @override
+  Future<String> getDownloadsPath() async => _tempDir.path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Directory tempRoot;
+  PathProviderPlatform originalPlatform;
+
+  setUpAll(() async {
+    tempRoot = await Directory.systemTemp.createTemp('navec_flow_test');
+    originalPlatform = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempRoot);
+  });
+
+  tearDownAll(() async {
+    PathProviderPlatform.instance = originalPlatform;
+    if (tempRoot != null && await tempRoot.exists()) {
+      await tempRoot.delete(recursive: true);
+    }
+  });
+
+  testWidgets('encryptFile embeds metadata and decryptFile restores content',
+      (tester) async {
+    const password = 'correct horse battery staple';
+    const uuid = '00000000-0000-0000-0000-000000000001';
+
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (context) {
+          return const SizedBox.shrink();
+        },
+      ),
+    ));
+
+    final BuildContext context = tester.element(find.byType(SizedBox));
+
+    final plainBytes = Uint8List.fromList(utf8.encode('Sensitive payload'));
+    final sourceFile = await File(p.join(tempRoot.path, 'sample.txt'))
+        .writeAsBytes(plainBytes, flush: true);
+
+    final algo = Navec.algorithms.firstWhere((item) => item.code == 'AES256');
+    final encryptedFile = await Navec.encryptFile(
+      filePath: sourceFile.path,
+      password: password,
+      algo: algo,
+      uuid: uuid,
+    );
+
+    addTearDown(() async {
+      if (await encryptedFile.exists()) {
+        await encryptedFile.delete();
+      }
+      if (await sourceFile.exists()) {
+        await sourceFile.delete();
+      }
+    });
+
+    expect(p.extension(encryptedFile.path), '.${Navec.encryptedFileExtension}');
+
+    final encryptedBytes = await encryptedFile.readAsBytes();
+    expect(
+      utf8.decode(
+        encryptedBytes.sublist(0, Navec.headerFileSignature.length),
+      ),
+      Navec.headerFileSignature,
+    );
+
+    final versionOffset = Navec.headerFileSignature.length;
+    expect(
+      utf8.decode(
+        encryptedBytes.sublist(
+          versionOffset,
+          versionOffset + Navec.headerVersion.length,
+        ),
+      ),
+      Navec.headerVersion,
+    );
+
+    final ivOffset = versionOffset +
+        Navec.headerVersion.length +
+        Navec.headerFileExtensionFieldLength +
+        Navec.headerAlgorithmFieldLength;
+    final ivBytes = encryptedBytes.sublist(ivOffset, ivOffset + Aes.ivLength);
+    expect(ivBytes.length, Aes.ivLength);
+
+    final uuidBytes = utf8.encode(uuid);
+    final uuidSlice = encryptedBytes.sublist(
+      encryptedBytes.length - uuidBytes.length,
+    );
+    expect(utf8.decode(uuidSlice), uuid);
+
+    final result = await Navec.decryptFile(
+      context: context,
+      filePath: encryptedFile.path,
+      password: password,
+    );
+
+    expect(result, isNotNull);
+    final File outputFile = result[0] as File;
+    addTearDown(() async {
+      if (await outputFile.exists()) {
+        await outputFile.delete();
+      }
+    });
+    final String recoveredUuid = result[1] as String;
+
+    expect(recoveredUuid, uuid);
+    final outputBytes = await outputFile.readAsBytes();
+    expect(outputBytes, plainBytes);
+  });
+}


### PR DESCRIPTION
## Summary
- add early validation and clearer user feedback in `Navec.decryptFile` for corrupt or non-NAVEC inputs
- introduce a widget test that exercises the AES happy path and verifies header metadata via a fake path provider

## Testing
- flutter test *(fails: Flutter SDK not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e1327714832280dd28c6b623ee2d