### PR TITLE
Handle legacy fallback in NAVEC parser

### DIFF
--- a/lib/navy_encryption/navec.dart
+++ b/lib/navy_encryption/navec.dart
@@ -308,7 +308,8 @@ class Navec {
       ));
       hasVersion = versionCandidate == Navec.headerVersion;
     }
-    final versionLength = hasVersion ? Navec.headerVersion.length : 0;
+
+    int versionLength = hasVersion ? Navec.headerVersion.length : 0;
 
     var extensionFieldBeginIndex = signatureLength + versionLength;
     var algorithmFieldBeginIndex =
@@ -326,21 +327,19 @@ class Navec {
         utf8.decode(fileBytes.sublist(0, Navec.headerFileSignature.length));
     logMap['File signature'] = fileSignature;
 
-    var fileExtension = utf8
+    String fileExtension = utf8
         .decode(fileBytes.sublist(
           extensionFieldBeginIndex,
           algorithmFieldBeginIndex,
         ))
         .trim();
-    logMap['File extension (old)'] = fileExtension;
 
-    var algoCode = utf8
+    String algoCode = utf8
         .decode(fileBytes.sublist(
           algorithmFieldBeginIndex,
           contentBeginIndex,
         ))
         .trim();
-    logMap['Algorithm'] = algoCode;
 
     var contentEndIndex = fileBytes.length;
     String uuid;
@@ -355,14 +354,59 @@ class Navec {
       contentEndIndex = contentEndIndex - headerUUIDFieldLength;
     } catch (err) {}
 
-    logMap['Header version'] = hasVersion ? Navec.headerVersion : '1';
-
-    logWithBorder(logMap, 2);
-
     var algo = Navec.algorithms.firstWhere(
       (algo) => algo.code == algoCode,
       orElse: () => null,
     );
+
+    bool shouldFallbackToLegacyLayout = false;
+
+    if (hasVersion) {
+      if (algo == null) {
+        shouldFallbackToLegacyLayout = true;
+      } else if (algo is Aes) {
+        final ivEndIndexCandidate = contentBeginIndex + Aes.ivLength;
+        if (ivEndIndexCandidate > contentEndIndex) {
+          shouldFallbackToLegacyLayout = true;
+        }
+      }
+    }
+
+    if (shouldFallbackToLegacyLayout) {
+      hasVersion = false;
+      versionLength = 0;
+      extensionFieldBeginIndex = signatureLength + versionLength;
+      algorithmFieldBeginIndex =
+          extensionFieldBeginIndex + Navec.headerFileExtensionFieldLength;
+      contentBeginIndex =
+          algorithmFieldBeginIndex + Navec.headerAlgorithmFieldLength;
+
+      fileExtension = utf8
+          .decode(fileBytes.sublist(
+            extensionFieldBeginIndex,
+            algorithmFieldBeginIndex,
+          ))
+          .trim();
+
+      algoCode = utf8
+          .decode(fileBytes.sublist(
+            algorithmFieldBeginIndex,
+            contentBeginIndex,
+          ))
+          .trim();
+
+      algo = Navec.algorithms.firstWhere(
+        (algo) => algo.code == algoCode,
+        orElse: () => null,
+      );
+
+    }
+
+    logMap['File extension (old)'] = fileExtension;
+    logMap['Algorithm'] = algoCode;
+    logMap['Header version'] = hasVersion ? Navec.headerVersion : '1';
+
+    logWithBorder(logMap, 2);
 
     if (algo == null) {
       showOkDialog(

--- a/test/navy_encryption/navec_flow_test.dart
+++ b/test/navy_encryption/navec_flow_test.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:encrypt/encrypt.dart' as enc;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:navy_encrypt/etc/file_util.dart';
+import 'package:navy_encrypt/navy_encryption/algorithms/aes.dart';
+import 'package:navy_encrypt/navy_encryption/navec.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProviderPlatform(this._tempDirPath);
+
+  final String _tempDirPath;
+
+  @override
+  Future<String> getTemporaryPath() async => _tempDirPath;
+
+  @override
+  Future<String> getApplicationDocumentsPath() async => _tempDirPath;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Navec decrypt flow', () {
+    const password = 'password123';
+    final originalBytes =
+        Uint8List.fromList(List<int>.generate(48, (index) => index));
+    const uuid = '12345678-1234-1234-1234-123456789012';
+    const originalExtension = '2data';
+
+    setUp(() async {
+      final tempDir = await Directory.systemTemp.createTemp('navec_test_');
+      final previousPlatform = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+      addTearDown(() async {
+        PathProviderPlatform.instance = previousPlatform;
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+    });
+
+    testWidgets('decrypts legacy layout files whose extension starts with 2',
+        (tester) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(
+          builder: (context) {
+            capturedContext = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      ));
+
+      await tester.runAsync(() async {
+        final aes = Aes(keyLengthInBytes: 16);
+        String legacyKeyText = password.trim();
+        while (legacyKeyText.length < aes.keyLengthInBytes) {
+          legacyKeyText = '$legacyKeyText${Navec.passwordPadChar}';
+        }
+        final legacyKey = enc.Key.fromUtf8(legacyKeyText);
+        final legacyIv = enc.IV.fromLength(Aes.ivLength);
+        final legacyEncrypter = enc.Encrypter(enc.AES(legacyKey));
+        final legacyEncrypted = legacyEncrypter.encryptBytes(
+          originalBytes,
+          iv: legacyIv,
+        );
+
+        final extensionField = originalExtension
+            .padRight(Navec.headerFileExtensionFieldLength);
+        final algoField = 'AES128'.padRight(Navec.headerAlgorithmFieldLength);
+
+        final payloadBytes = <int>[
+          ...utf8.encode(Navec.headerFileSignature),
+          ...utf8.encode(extensionField),
+          ...utf8.encode(algoField),
+          ...legacyEncrypted.bytes,
+          ...utf8.encode(uuid),
+        ];
+
+        final encryptedFile = await FileUtil.createFileFromBytes(
+          'legacy.enc',
+          Uint8List.fromList(payloadBytes),
+        );
+
+        final result = await Navec.decryptFile(
+          context: capturedContext,
+          filePath: encryptedFile.path,
+          password: password,
+        );
+
+        expect(result, isNotNull);
+        expect(result.length, 2);
+
+        final File decryptedFile = result.first as File;
+        final String decryptedUuid = result.last as String;
+
+        expect(decryptedUuid, uuid);
+        expect(await decryptedFile.readAsBytes(), originalBytes);
+        expect(p.extension(decryptedFile.path), '.${originalExtension.trim()}');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- update NAVEC decryption to retry with the legacy layout when the algorithm lookup fails or the IV slice is incomplete
- delay IV extraction until the new-layout bounds are confirmed so the legacy AES fallback can still run
- add a widget regression test that covers decrypting a legacy payload whose extension starts with `2`

## Testing
- Not run (flutter tooling unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e5ed9e4cc88322a2ae99ed847e2836