### PR TITLE
Guard HttpOverrides against production builds

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,7 +45,11 @@ Future<void> main(List<String> arguments) async {
     DeviceOrientation.portraitUp,
   ]);
 
-  HttpOverrides.global = new MyHttpOverrides();
+  const bool isProductMode = bool.fromEnvironment('dart.vm.product');
+
+  if (!isProductMode) {
+    HttpOverrides.global = MyHttpOverrides();
+  }
 
   //#region Firebase
 


### PR DESCRIPTION
## Summary
- guard the global HttpOverrides assignment behind a product-mode check so release builds do not trust invalid certificates

## Testing
- ⚠️ `flutter test` *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5fbba3ce08322a39317283635e56a