### PR TITLE
Remove duplicate home menu definitions

### DIFF
--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -959,46 +959,6 @@ class _HomeMenuAction {
   String get label => labelBuilder();
 }
 
-typedef _MenuActionHandler = FutureOr<void> Function(BuildContext context);
-
-class _HomeMenuAction {
-  const _HomeMenuAction({
-    @required this.assetPath,
-    @required this.labelBuilder,
-    @required this.onTap,
-    bool Function() isVisible,
-  }) : _isVisiblePredicate = isVisible;
-
-  final String assetPath;
-  final String Function() labelBuilder;
-  final _MenuActionHandler onTap;
-  final bool Function() _isVisiblePredicate;
-
-  bool get isVisible => _isVisiblePredicate?.call() ?? true;
-
-  String get label => labelBuilder();
-}
-
-typedef _MenuActionHandler = FutureOr<void> Function(BuildContext context);
-
-class _HomeMenuAction {
-  const _HomeMenuAction({
-    @required this.assetPath,
-    @required this.labelBuilder,
-    @required this.onTap,
-    bool Function() isVisible,
-  }) : _isVisiblePredicate = isVisible;
-
-  final String assetPath;
-  final String Function() labelBuilder;
-  final _MenuActionHandler onTap;
-  final bool Function() _isVisiblePredicate;
-
-  bool get isVisible => _isVisiblePredicate?.call() ?? true;
-
-  String get label => labelBuilder();
-}
-
 class _HomeQuickAction {
   const _HomeQuickAction({
     @required this.icon,


### PR DESCRIPTION
## Summary
- remove the duplicate typedef and class definitions for home page menu actions so only one remains

## Testing
- dart analyze *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e6108e94348322b48deb8156fd5c23