### PR TITLE
Fix package info helper to avoid undefined variables

### DIFF
--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -915,8 +915,6 @@ class HomePageController extends MyState<HomePage> {
 
   Future<PackageInfo> _getPackageInfo() async {
     return await PackageInfo.fromPlatform();
-
-    return 'เวอร์ชัน $version+$buildNumber';
   }
 
   String buildVersionLabel(PackageInfo packageInfo) {


### PR DESCRIPTION
## Summary
- remove the unreachable return statement in `_getPackageInfo` that referenced undefined variables

## Testing
- dart analyze *(fails: dart command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6108d6d8883229f8c5784ae5ad7f8