### PR TITLE
Expose package info future for home page view

### DIFF
--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -915,8 +915,6 @@ class HomePageController extends MyState<HomePage> {
 
   Future<PackageInfo> _getPackageInfo() async {
     return await PackageInfo.fromPlatform();
-
-    return 'เวอร์ชัน $version+$buildNumber';
   }
 
   String buildVersionLabel(PackageInfo packageInfo) {
@@ -1016,3 +1014,10 @@ class _HomeQuickAction {
 
   bool get isVisible => _isVisiblePredicate?.call() ?? true;
 }
+  Future<PackageInfo> get packageInfoFuture =>
+      _packageInfoFuture ??= _getPackageInfo();
+
+  void refreshPackageInfo() {
+    _packageInfoFuture = null;
+  }
+


### PR DESCRIPTION
## Summary
- expose the cached package info future through a getter for the home page controller
- add a refresh helper so the cached future can be invalidated when needed

## Testing
- `flutter test` *(fails: Flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6108c347883229e202c97b2710728