### PR TITLE
Fix package info accessors scope on home page

### DIFF
--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -961,6 +961,13 @@ class HomePageController extends MyState<HomePage> {
     return EncryptionPage.routeName;
   }
 
+  Future<PackageInfo> get packageInfoFuture =>
+      _packageInfoFuture ??= _getPackageInfo();
+
+  void refreshPackageInfo() {
+    _packageInfoFuture = null;
+  }
+
   Future<PackageInfo> _getPackageInfo() async {
     return await PackageInfo.fromPlatform();
   }
@@ -1022,10 +1029,4 @@ class _HomeQuickAction {
 
   bool get isVisible => _isVisiblePredicate?.call() ?? true;
 }
-  Future<PackageInfo> get packageInfoFuture =>
-      _packageInfoFuture ??= _getPackageInfo();
-
-  void refreshPackageInfo() {
-    _packageInfoFuture = null;
-  }
 


### PR DESCRIPTION
## Summary
- move the `packageInfoFuture` getter and `refreshPackageInfo` helper into `HomePageController`
- ensure these helpers can reference the controller's cached `_packageInfoFuture`

## Testing
- dart analyze *(fails: dart command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6133f09f48322a85b3ee21c390336