### PR TITLE
Show quick actions on mobile home layout

### DIFF
--- a/lib/pages/home/home_page_view.dart
+++ b/lib/pages/home/home_page_view.dart
@@ -8,6 +8,7 @@ class _HomePageView extends WidgetView<HomePage, HomePageController> {
     var width = screenWidth(context);
     var height = screenHeight(context);
     final menuActions = state.menuActions;
+    final quickActions = state.quickActions;
 
     return HeaderScaffold(
       showBackButton: false,
@@ -61,6 +62,22 @@ class _HomePageView extends WidgetView<HomePage, HomePageController> {
       body: Column(
         mainAxisAlignment: MainAxisAlignment.start,
         children: [
+          if (quickActions.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12.0),
+              child: Wrap(
+                alignment: WrapAlignment.center,
+                spacing: 12.0,
+                runSpacing: 10.0,
+                children: quickActions
+                    .map(
+                      (action) => _QuickActionButton(
+                        action: action,
+                      ),
+                    )
+                    .toList(growable: false),
+              ),
+            ),
           for (var i = 0; i < menuActions.length; i += 2)
             Row(
               children: [


### PR DESCRIPTION
## Summary
- expose the existing quick action buttons on the mobile home screen layout so they render when available

## Testing
- not run (dart/flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e60f0f027083229d36f54263b2c12e